### PR TITLE
Update to Scala 2.10.0, ScalaTest 1.9.1

### DIFF
--- a/framework-src/project/Build.scala
+++ b/framework-src/project/Build.scala
@@ -11,15 +11,16 @@ object ApplicationBuild extends Build {
       name := "factory_pal",
       organization := "ar.com.gonto",
       version := "0.1.1-SNAPSHOT",
-      scalaVersion := "2.10.0-RC3",
+      scalaVersion := "2.10.0",
+      scalacOptions := Seq("-deprecation", "-feature"),
       licenses      := ("Apache2", new java.net.URL("http://www.apache.org/licenses/LICENSE-2.0.txt")) :: Nil,
       libraryDependencies ++= Seq(
-       "org.scalatest" % "scalatest_2.10.0-RC3" % "1.8-B1" % "test",
-       "org.scala-lang" % "scala-compiler" % "2.10.0-RC3"
+       "org.scalatest" % "scalatest_2.10" % "1.9.1" % "test",
+       "org.scala-lang" % "scala-compiler" % "2.10.0"
       ),
       resolvers ++= Seq(
          "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
-         "OSS SonarType" at "https://oss.sonatype.org/content/groups/public/"
+         "OSS SonaType" at "https://oss.sonatype.org/content/groups/public/"
       )
 
       // add other settings here


### PR DESCRIPTION
Also, enable feature and deprecation warnings for further reference

All tests pass and I do not see why there would be any problems updating to 2.10.0 final.

Should fix #2
