### PR TITLE
Clean up feature warnings about postfix operators

### DIFF
--- a/framework-src/src/test/scala/ar/com/gonto/factorypal/FactoryPalSpec.scala
+++ b/framework-src/src/test/scala/ar/com/gonto/factorypal/FactoryPalSpec.scala
@@ -77,7 +77,7 @@ class FactoryPalSpec extends FunSpec with ShouldMatchers {
 
       val newName = "pepe"
       val person = FactoryPal.create[Person]() { person =>
-        person.name.mapsTo(newName) alone
+        person.name.mapsTo(newName).alone
       }
 
       person.name should equal(newName)
@@ -88,7 +88,7 @@ class FactoryPalSpec extends FunSpec with ShouldMatchers {
       val companyName = "gonto"
       val employeeName = "gontoEmployee"
       FactoryPal.register[Company]() { company =>
-        company.name.mapsTo(companyName) alone
+        company.name.mapsTo(companyName).alone
       }
 
       FactoryPal.register[Employee]() { employee =>


### PR DESCRIPTION
There were two warnings about postfix operators, this removes them.
They were not really an issue, but it is nicer and cleaner this way.

Here is what it said when running `sbt test`:

```
[warn] /Volumes/Data/Dropbox/_src/_Scala/factory_pal/framework-src/src/test/scala/ar/com/gonto/factorypal/FactoryPalSpec.scala:80: postfix operator alone should be enabled
[warn] by making the implicit value language.postfixOps visible.
[warn] This can be achieved by adding the import clause 'import scala.language.postfixOps'
[warn] or by setting the compiler option -language:postfixOps.
[warn] See the Scala docs for value scala.language.postfixOps for a discussion
[warn] why the feature should be explicitly enabled.
[warn]         person.name.mapsTo(newName) alone
[warn]                                     ^
[warn] /Volumes/Data/Dropbox/_src/_Scala/factory_pal/framework-src/src/test/scala/ar/com/gonto/factorypal/FactoryPalSpec.scala:91: postfix operator alone should be enabled
[warn] by making the implicit value language.postfixOps visible.
[warn]         company.name.mapsTo(companyName) alone
[warn]                                          ^
[warn] two warnings found
```
